### PR TITLE
add meta options to base Module class

### DIFF
--- a/lib/core/module.py
+++ b/lib/core/module.py
@@ -11,22 +11,27 @@ from lib.core import base
 class Module(base.Base):
     """Module of framework"""
 
-    Name = ''
-    Description = ''
-    Author = ''
-    References = ''
-    License = ''
+    meta = {
+        'name': '',
+        'author': '',
+        'description': '',
+        'comments': '',
+        'references': [],
+        'license': '',
+        'options': {
+            # 'key': [value, default, description]
+        }
+    }
 
     def __init__(self):
         base.Base.__init__(self, verbose=False)
 
+        # self.register_option(self, key, value, default, description):
+        for option in self.meta['options'].items():
+            (key, [value, default_value, desc]) = option
+            self.register_option(key, value, default_value, desc)
+
     def show_options(self):
-        rjust_length = 18
-        self.output('')
-        self.output("  Name: %s".rjust(rjust_length) % self.Name)
-        self.output("  Description: %s".rjust(rjust_length) % self.Description)
-        self.output("  Author: %s".rjust(rjust_length) % self.Author)
-        self.output("  References: %s".rjust(rjust_length) % self.References)
         base.Base.show_options(self)
 
     def do_run(self, *args, **kwargs):


### PR DESCRIPTION
Module can register options with **```meta```**, a demo shows as follow:

```
open-security-framework [development] python osfconsole.py
Open-Security-Framework > show modules

    exploits/multi/http/apache_struts_dmi_rce

Open-Security-Framework > use exploits/multi/http/apache_struts_dmi_rce
Open-Security-Framework (exploits/multi/http/apache_struts_dmi_rce) > show options

    Option     Current Setting  Description
    ---------  ---------------  --------------------------
    TARGETURI  /index.action    target uri to request
    THREADS    1                Set default threads number
    VERBOSE    False            Verbose mode
    RPORT      80               the target port
    RHOST      www.example.com  the target host

Open-Security-Framework (exploits/multi/http/apache_struts_dmi_rce) > run
Apache Struts s2_032 Remote Code Execution
www.example.com:80/index.action
```